### PR TITLE
Decrease time it takes to build executive documents

### DIFF
--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -1,0 +1,26 @@
+name: Deploy to ghcr.io
+
+on:
+  push:
+    branches:
+      - rebuild-base-img
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2.0.0
+        with:
+          registry: ghcr.io
+          username: muncomputersciencesociety
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3.1.1
+        with:
+          push: true
+          tags: ghcr.io/muncomputersciencesociety/executive-docs-base-img:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,18 +8,15 @@ jobs:
   build:
     name: Build documents
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/muncomputersciencesociety/executive-docs-base-img:latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-
+        uses: actions/checkout@v3
       - name: Compile documents
         run: |
-          sudo apt-get update
-          sudo apt-get install -y pandoc texlive-full texlive-fonts-recommended
-          pip install -r requirements.txt
           mkdir -p ./executive-documents/
           python3 cli.py builddocs --base /~csclub/executive-documents/ --input . --output ./executive-documents/
-
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:latest
+
+RUN apt-get -y update
+RUN DEBIAN_FRONTEND=noninteractive TZ=America/St_Johns apt-get install -y pandoc texlive-full texlive-fonts-recommended python3-pip
+RUN pip install --upgrade pip
+
+COPY requirements.txt /tmp/requirements.txt
+
+RUN pip install -r /tmp/requirements.txt


### PR DESCRIPTION
- This was a way in which I thought of. So we have an additional workflow that can be run manually, right now it's just a branch tag, I wasn't sure if there was a more efficient way here.

- To build and publish the documents it will just have to pull in the latest image from ghcr. The time savings on this is big.

- Originally I was trying to using the cache action but realized it was not capable of taking the apt packages.

closes #15 